### PR TITLE
Fix wrangler.toml routes array syntax

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,6 @@ binding = "DB"
 database_name = "url-shortener"
 database_id = "b47f73ea-a441-4f8f-986b-5080a7d2a1c9"
 
-[routes]
+[[routes]]
 pattern = "links.jbcloud.app/*"
 custom_domain = true


### PR DESCRIPTION
Change [routes] to [[routes]] to fix TOML array syntax error. The error was: Expected "routes" to be an array but got object.