### PR TITLE
Fix route pattern for links.jbcloud.app domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,5 +8,5 @@ database_name = "url-shortener"
 database_id = "b47f73ea-a441-4f8f-986b-5080a7d2a1c9"
 
 [[routes]]
-pattern = "links.jbcloud.app/*"
+pattern = "links.jbcloud.app"
 custom_domain = true


### PR DESCRIPTION
## Summary
Updated the route pattern configuration in wrangler.toml to correctly match the links.jbcloud.app domain without the wildcard suffix.

## Changes
- Modified the route pattern from `links.jbcloud.app/*` to `links.jbcloud.app`
  - This ensures the custom domain routing is properly configured for the exact domain rather than attempting to match subpaths with a wildcard pattern

## Details
The route pattern change allows the Cloudflare Worker to correctly handle requests to the links.jbcloud.app domain. The removal of the `/*` wildcard suffix indicates that routing should be handled at the domain level rather than relying on path-based pattern matching at the configuration level.