### PR TITLE
feat(mobile): scaffold Expo React Native companion app

### DIFF
--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import AppNavigator from './src/navigation/AppNavigator';
+import { loadAuthToken, setAuthToken } from './src/services/api';
+
+export default function App() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    checkAuth();
+  }, []);
+
+  const checkAuth = async () => {
+    try {
+      const token = await loadAuthToken();
+      setIsAuthenticated(!!token);
+    } catch (error) {
+      console.error('Auth check failed:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogin = async (token) => {
+    // For development, we'll auto-authenticate
+    // In production, this would receive the actual JWT from Cloudflare Access
+    await setAuthToken(token || 'dev-token');
+    setIsAuthenticated(true);
+  };
+
+  const handleLogout = async () => {
+    await setAuthToken(null);
+    setIsAuthenticated(false);
+  };
+
+  if (isLoading) {
+    return null; // Or a splash screen
+  }
+
+  return (
+    <SafeAreaProvider>
+      <StatusBar style="light" />
+      <AppNavigator
+        isAuthenticated={isAuthenticated}
+        onLogin={handleLogin}
+        onLogout={handleLogout}
+      />
+    </SafeAreaProvider>
+  );
+}

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -1,0 +1,34 @@
+{
+  "expo": {
+    "name": "LinkShort",
+    "slug": "linkshort",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "dark",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#0a0a0a"
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": false,
+      "bundleIdentifier": "com.yourname.linkshort",
+      "buildNumber": "1"
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#0a0a0a"
+      },
+      "package": "com.yourname.linkshort"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "your-project-id"
+      }
+    },
+    "plugins": []
+  }
+}

--- a/mobile-app/babel.config.js
+++ b/mobile-app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "linkshort-mobile",
+  "version": "1.0.0",
+  "main": "expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "ios": "expo run:ios",
+    "android": "expo run:android",
+    "build:ios": "eas build --platform ios",
+    "build:android": "eas build --platform android"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^14.0.0",
+    "@react-navigation/bottom-tabs": "^6.5.11",
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.17",
+    "expo": "~50.0.0",
+    "expo-clipboard": "~5.0.1",
+    "expo-haptics": "~12.8.1",
+    "expo-secure-store": "~12.8.1",
+    "expo-status-bar": "~1.11.1",
+    "expo-web-browser": "~12.8.2",
+    "react": "18.2.0",
+    "react-native": "0.73.2",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
+    "react-native-svg": "14.1.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  },
+  "private": true
+}

--- a/mobile-app/src/components/LinkCard.js
+++ b/mobile-app/src/components/LinkCard.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+
+export default function LinkCard({ link, onPress, onCopy, onDelete }) {
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  const truncateUrl = (url, maxLength = 35) => {
+    if (!url) return '';
+    // Remove protocol
+    const clean = url.replace(/^https?:\/\//, '');
+    if (clean.length <= maxLength) return clean;
+    return clean.substring(0, maxLength) + '...';
+  };
+
+  const getCategoryColor = (colorName) => {
+    const categoryColors = {
+      work: colors.categories.work,
+      personal: colors.categories.personal,
+      social: colors.categories.social,
+      marketing: colors.categories.marketing,
+    };
+    return categoryColors[colorName] || colors.mutedForeground;
+  };
+
+  return (
+    <TouchableOpacity
+      style={styles.container}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
+      <View style={styles.content}>
+        {/* Short URL */}
+        <View style={styles.row}>
+          <View style={styles.codeContainer}>
+            {link.is_protected && (
+              <Feather
+                name="lock"
+                size={12}
+                color={colors.indigo}
+                style={styles.lockIcon}
+              />
+            )}
+            <Text style={styles.code}>/{link.code}</Text>
+          </View>
+          <View style={styles.actions}>
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={onCopy}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Feather name="copy" size={16} color={colors.mutedForeground} />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={onDelete}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Feather name="trash-2" size={16} color={colors.mutedForeground} />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* Destination URL */}
+        <Text style={styles.destination} numberOfLines={1}>
+          {truncateUrl(link.destination)}
+        </Text>
+
+        {/* Meta row */}
+        <View style={styles.metaRow}>
+          {/* Category badge */}
+          {link.category_name && (
+            <View
+              style={[
+                styles.categoryBadge,
+                { backgroundColor: `${getCategoryColor(link.category_color)}20` },
+              ]}
+            >
+              <View
+                style={[
+                  styles.categoryDot,
+                  { backgroundColor: getCategoryColor(link.category_color) },
+                ]}
+              />
+              <Text
+                style={[
+                  styles.categoryText,
+                  { color: getCategoryColor(link.category_color) },
+                ]}
+              >
+                {link.category_name}
+              </Text>
+            </View>
+          )}
+
+          {/* Clicks */}
+          <View style={styles.clicksContainer}>
+            <Feather name="mouse-pointer" size={12} color={colors.mutedForeground} />
+            <Text style={styles.clicks}>{link.clicks}</Text>
+          </View>
+
+          {/* Date */}
+          <Text style={styles.date}>{formatDate(link.created_at)}</Text>
+        </View>
+
+        {/* Tags */}
+        {link.tags && link.tags.length > 0 && (
+          <View style={styles.tagsRow}>
+            {link.tags.slice(0, 3).map((tag, index) => (
+              <View key={index} style={styles.tag}>
+                <Text style={styles.tagText}>{tag}</Text>
+              </View>
+            ))}
+            {link.tags.length > 3 && (
+              <Text style={styles.moreText}>+{link.tags.length - 3}</Text>
+            )}
+          </View>
+        )}
+      </View>
+
+      {/* Chevron */}
+      <Feather name="chevron-right" size={20} color={colors.mutedForeground} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.card,
+    marginHorizontal: spacing.xl,
+    marginTop: spacing.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+  },
+  content: {
+    flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  codeContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  lockIcon: {
+    marginRight: spacing.xs,
+  },
+  code: {
+    fontSize: typography.lg,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  actionButton: {
+    padding: spacing.xs,
+  },
+  destination: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginBottom: spacing.md,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  categoryBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.sm,
+    gap: spacing.xs,
+  },
+  categoryDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  categoryText: {
+    fontSize: typography.xs,
+    fontWeight: typography.medium,
+  },
+  clicksContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  clicks: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+  },
+  date: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing.sm,
+    gap: spacing.sm,
+  },
+  tag: {
+    backgroundColor: colors.muted,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs - 2,
+    borderRadius: borderRadius.sm,
+  },
+  tagText: {
+    fontSize: typography.xs,
+    color: colors.mutedForeground,
+  },
+  moreText: {
+    fontSize: typography.xs,
+    color: colors.mutedForeground,
+  },
+});

--- a/mobile-app/src/components/StatsCard.js
+++ b/mobile-app/src/components/StatsCard.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+
+export default function StatsCard({ icon, value, label }) {
+  // Format large numbers
+  const formatNumber = (num) => {
+    if (num >= 1000000) {
+      return (num / 1000000).toFixed(1) + 'M';
+    }
+    if (num >= 1000) {
+      return (num / 1000).toFixed(1) + 'K';
+    }
+    return num.toString();
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconContainer}>
+        <Feather name={icon} size={16} color={colors.indigo} />
+      </View>
+      <Text style={styles.value}>{formatNumber(value)}</Text>
+      <Text style={styles.label}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+  },
+  iconContainer: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.md,
+    backgroundColor: `${colors.indigo}20`,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  value: {
+    fontSize: typography.xxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+    marginBottom: 2,
+  },
+  label: {
+    fontSize: typography.xs,
+    color: colors.mutedForeground,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+});

--- a/mobile-app/src/components/index.js
+++ b/mobile-app/src/components/index.js
@@ -1,0 +1,2 @@
+export { default as StatsCard } from './StatsCard';
+export { default as LinkCard } from './LinkCard';

--- a/mobile-app/src/constants/config.js
+++ b/mobile-app/src/constants/config.js
@@ -1,0 +1,10 @@
+// API Configuration
+// Update this to your Cloudflare Worker URL
+export const API_BASE_URL = 'https://your-url-shortener.your-subdomain.workers.dev';
+
+// For development, you might use:
+// export const API_BASE_URL = 'http://localhost:8787';
+
+export default {
+  API_BASE_URL,
+};

--- a/mobile-app/src/constants/theme.js
+++ b/mobile-app/src/constants/theme.js
@@ -1,0 +1,113 @@
+// Design tokens matching the web app's Shadcn-style dark theme
+export const colors = {
+  // Core
+  background: '#0a0a0a',
+  foreground: '#fafafa',
+
+  // Card
+  card: '#171717',
+  cardForeground: '#fafafa',
+
+  // Muted
+  muted: '#262626',
+  mutedForeground: '#a1a1aa',
+
+  // Border
+  border: '#262626',
+
+  // Primary (white in dark mode)
+  primary: '#fafafa',
+  primaryForeground: '#171717',
+
+  // Accent
+  accent: '#262626',
+  accentForeground: '#fafafa',
+
+  // Indigo (brand color)
+  indigo: '#818cf8',
+  indigoLight: '#a5b4fc',
+  indigoDark: '#6366f1',
+
+  // Category colors
+  categories: {
+    work: '#a855f7',      // Purple
+    personal: '#ec4899',   // Pink
+    social: '#06b6d4',     // Cyan
+    marketing: '#f97316',  // Orange
+  },
+
+  // Status colors
+  success: '#22c55e',
+  warning: '#eab308',
+  error: '#ef4444',
+
+  // Transparent
+  transparent: 'transparent',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
+};
+
+export const borderRadius = {
+  sm: 6,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  full: 9999,
+};
+
+export const typography = {
+  // Font sizes
+  xs: 11,
+  sm: 13,
+  base: 15,
+  lg: 17,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
+
+  // Font weights (as strings for React Native)
+  regular: '400',
+  medium: '500',
+  semibold: '600',
+  bold: '700',
+};
+
+export const shadows = {
+  sm: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  md: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  lg: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.4,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+};
+
+export default {
+  colors,
+  spacing,
+  borderRadius,
+  typography,
+  shadows,
+};

--- a/mobile-app/src/navigation/AppNavigator.js
+++ b/mobile-app/src/navigation/AppNavigator.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import TabNavigator from './TabNavigator';
+import CreateLinkScreen from '../screens/CreateLinkScreen';
+import LinkDetailScreen from '../screens/LinkDetailScreen';
+import LoginScreen from '../screens/LoginScreen';
+import { colors } from '../constants/theme';
+
+const Stack = createNativeStackNavigator();
+
+export default function AppNavigator({ isAuthenticated, onLogin, onLogout }) {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          headerStyle: {
+            backgroundColor: colors.background,
+          },
+          headerTintColor: colors.foreground,
+          headerTitleStyle: {
+            fontWeight: '600',
+          },
+          contentStyle: {
+            backgroundColor: colors.background,
+          },
+        }}
+      >
+        {!isAuthenticated ? (
+          <Stack.Screen
+            name="Login"
+            options={{ headerShown: false }}
+          >
+            {(props) => <LoginScreen {...props} onLogin={onLogin} />}
+          </Stack.Screen>
+        ) : (
+          <>
+            <Stack.Screen
+              name="Main"
+              options={{ headerShown: false }}
+            >
+              {(props) => <TabNavigator {...props} onLogout={onLogout} />}
+            </Stack.Screen>
+            <Stack.Screen
+              name="CreateLink"
+              component={CreateLinkScreen}
+              options={{
+                presentation: 'modal',
+                title: 'New Link',
+              }}
+            />
+            <Stack.Screen
+              name="LinkDetail"
+              component={LinkDetailScreen}
+              options={{
+                title: 'Link Details',
+              }}
+            />
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile-app/src/navigation/TabNavigator.js
+++ b/mobile-app/src/navigation/TabNavigator.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Feather } from '@expo/vector-icons';
+
+import LinksScreen from '../screens/LinksScreen';
+import AnalyticsScreen from '../screens/AnalyticsScreen';
+import CategoriesScreen from '../screens/CategoriesScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+import { colors, spacing } from '../constants/theme';
+
+const Tab = createBottomTabNavigator();
+
+// Custom center button for "Add" action
+const AddButton = ({ onPress }) => (
+  <TouchableOpacity style={styles.addButton} onPress={onPress} activeOpacity={0.8}>
+    <View style={styles.addButtonInner}>
+      <Feather name="plus" size={28} color="#fff" />
+    </View>
+  </TouchableOpacity>
+);
+
+// Placeholder component for the Add tab (never actually shown)
+const AddPlaceholder = () => null;
+
+export default function TabNavigator({ navigation, onLogout }) {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarStyle: styles.tabBar,
+        tabBarActiveTintColor: colors.foreground,
+        tabBarInactiveTintColor: colors.mutedForeground,
+        tabBarShowLabel: true,
+        tabBarLabelStyle: styles.tabBarLabel,
+      }}
+    >
+      <Tab.Screen
+        name="Links"
+        component={LinksScreen}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Feather name="link" size={22} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Analytics"
+        component={AnalyticsScreen}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Feather name="bar-chart-2" size={22} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Add"
+        component={AddPlaceholder}
+        options={{
+          tabBarButton: (props) => (
+            <AddButton
+              onPress={() => navigation.navigate('CreateLink')}
+            />
+          ),
+        }}
+        listeners={{
+          tabPress: (e) => {
+            e.preventDefault();
+            navigation.navigate('CreateLink');
+          },
+        }}
+      />
+      <Tab.Screen
+        name="Categories"
+        component={CategoriesScreen}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Feather name="grid" size={22} color={color} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Settings"
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Feather name="settings" size={22} color={color} />
+          ),
+        }}
+      >
+        {(props) => <SettingsScreen {...props} onLogout={onLogout} />}
+      </Tab.Screen>
+    </Tab.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  tabBar: {
+    backgroundColor: colors.card,
+    borderTopColor: colors.border,
+    borderTopWidth: 1,
+    height: 85,
+    paddingTop: spacing.sm,
+    paddingBottom: 25,
+  },
+  tabBarLabel: {
+    fontSize: 11,
+    fontWeight: '500',
+    marginTop: 4,
+  },
+  addButton: {
+    top: -20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  addButtonInner: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: colors.indigo,
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: colors.indigo,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+});

--- a/mobile-app/src/screens/AnalyticsScreen.js
+++ b/mobile-app/src/screens/AnalyticsScreen.js
@@ -1,0 +1,286 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  RefreshControl,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+import { statsApi } from '../services/api';
+
+export default function AnalyticsScreen() {
+  const [stats, setStats] = useState(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadStats = useCallback(async () => {
+    try {
+      const data = await statsApi.get();
+      setStats(data);
+    } catch (error) {
+      console.error('Failed to load stats:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadStats();
+    setRefreshing(false);
+  }, [loadStats]);
+
+  const StatBlock = ({ icon, value, label, color = colors.indigo }) => (
+    <View style={styles.statBlock}>
+      <View style={[styles.statIcon, { backgroundColor: `${color}20` }]}>
+        <Feather name={icon} size={20} color={color} />
+      </View>
+      <Text style={styles.statValue}>{value || 0}</Text>
+      <Text style={styles.statLabel}>{label}</Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.titleBar}>
+        <Text style={styles.title}>Analytics</Text>
+      </View>
+
+      <ScrollView
+        style={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.indigo}
+          />
+        }
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Overview Stats */}
+        <Text style={styles.sectionTitle}>Overview</Text>
+        <View style={styles.statsGrid}>
+          <StatBlock
+            icon="link"
+            value={stats?.total_links}
+            label="Total Links"
+          />
+          <StatBlock
+            icon="mouse-pointer"
+            value={stats?.total_clicks}
+            label="Total Clicks"
+            color={colors.success}
+          />
+          <StatBlock
+            icon="trending-up"
+            value={stats?.clicks_today}
+            label="Clicks Today"
+            color={colors.warning}
+          />
+          <StatBlock
+            icon="calendar"
+            value={stats?.links_this_week}
+            label="Links This Week"
+            color={colors.categories.personal}
+          />
+        </View>
+
+        {/* Top Performing Links */}
+        <Text style={styles.sectionTitle}>Top Performing</Text>
+        <View style={styles.card}>
+          {stats?.top_links?.length > 0 ? (
+            stats.top_links.map((link, index) => (
+              <View
+                key={link.code}
+                style={[
+                  styles.topLinkRow,
+                  index < stats.top_links.length - 1 && styles.topLinkBorder,
+                ]}
+              >
+                <View style={styles.topLinkRank}>
+                  <Text style={styles.rankText}>{index + 1}</Text>
+                </View>
+                <View style={styles.topLinkInfo}>
+                  <Text style={styles.topLinkCode}>/{link.code}</Text>
+                  <Text style={styles.topLinkDest} numberOfLines={1}>
+                    {link.destination}
+                  </Text>
+                </View>
+                <View style={styles.topLinkClicks}>
+                  <Feather name="mouse-pointer" size={12} color={colors.mutedForeground} />
+                  <Text style={styles.topLinkClicksText}>{link.clicks}</Text>
+                </View>
+              </View>
+            ))
+          ) : (
+            <View style={styles.emptyCard}>
+              <Feather name="bar-chart-2" size={32} color={colors.mutedForeground} />
+              <Text style={styles.emptyText}>No data yet</Text>
+            </View>
+          )}
+        </View>
+
+        {/* Click Rate Info */}
+        <Text style={styles.sectionTitle}>Insights</Text>
+        <View style={styles.card}>
+          <View style={styles.insightRow}>
+            <Feather name="activity" size={18} color={colors.indigo} />
+            <View style={styles.insightContent}>
+              <Text style={styles.insightTitle}>Average Clicks</Text>
+              <Text style={styles.insightValue}>
+                {stats?.total_links > 0
+                  ? Math.round(stats.total_clicks / stats.total_links)
+                  : 0}{' '}
+                per link
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={{ height: 100 }} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  titleBar: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+  },
+  title: {
+    fontSize: typography.xxxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+  },
+  sectionTitle: {
+    fontSize: typography.lg,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+    marginTop: spacing.xl,
+    marginBottom: spacing.md,
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+  },
+  statBlock: {
+    width: '48%',
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+  },
+  statIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.sm,
+  },
+  statValue: {
+    fontSize: typography.xxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+  },
+  statLabel: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: spacing.xs,
+  },
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+  },
+  topLinkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+  },
+  topLinkBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  topLinkRank: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: colors.muted,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.md,
+  },
+  rankText: {
+    fontSize: typography.sm,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+  },
+  topLinkInfo: {
+    flex: 1,
+  },
+  topLinkCode: {
+    fontSize: typography.base,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+  },
+  topLinkDest: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  topLinkClicks: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  topLinkClicksText: {
+    fontSize: typography.sm,
+    fontWeight: typography.medium,
+    color: colors.mutedForeground,
+  },
+  insightRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  insightContent: {
+    flex: 1,
+  },
+  insightTitle: {
+    fontSize: typography.base,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+  },
+  insightValue: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  emptyCard: {
+    alignItems: 'center',
+    paddingVertical: spacing.xl,
+  },
+  emptyText: {
+    fontSize: typography.base,
+    color: colors.mutedForeground,
+    marginTop: spacing.md,
+  },
+});

--- a/mobile-app/src/screens/CategoriesScreen.js
+++ b/mobile-app/src/screens/CategoriesScreen.js
@@ -1,0 +1,320 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+import { categoriesApi, tagsApi } from '../services/api';
+
+export default function CategoriesScreen() {
+  const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [refreshing, setRefreshing] = useState(false);
+  const [activeTab, setActiveTab] = useState('categories');
+
+  const loadData = useCallback(async () => {
+    try {
+      const [catsData, tagsData] = await Promise.all([
+        categoriesApi.getAll(),
+        tagsApi.getAll(),
+      ]);
+      setCategories(catsData || []);
+      setTags(tagsData || []);
+    } catch (error) {
+      console.error('Failed to load data:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadData();
+    setRefreshing(false);
+  }, [loadData]);
+
+  const getCategoryColor = (colorName) => {
+    const categoryColors = {
+      work: colors.categories.work,
+      personal: colors.categories.personal,
+      social: colors.categories.social,
+      marketing: colors.categories.marketing,
+    };
+    return categoryColors[colorName] || colors.mutedForeground;
+  };
+
+  const handleDeleteCategory = (id, name) => {
+    Alert.alert(
+      'Delete Category',
+      `Are you sure you want to delete "${name}"?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await categoriesApi.delete(id);
+              loadData();
+            } catch (error) {
+              Alert.alert('Error', 'Failed to delete category');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleDeleteTag = (id, name) => {
+    Alert.alert(
+      'Delete Tag',
+      `Are you sure you want to delete "${name}"?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await tagsApi.delete(id);
+              loadData();
+            } catch (error) {
+              Alert.alert('Error', 'Failed to delete tag');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const renderCategoryItem = ({ item }) => (
+    <View style={styles.itemCard}>
+      <View style={styles.itemContent}>
+        <View
+          style={[
+            styles.categoryDot,
+            { backgroundColor: getCategoryColor(item.color) },
+          ]}
+        />
+        <View style={styles.itemInfo}>
+          <Text style={styles.itemName}>{item.name}</Text>
+          <Text style={styles.itemMeta}>{item.link_count || 0} links</Text>
+        </View>
+      </View>
+      <TouchableOpacity
+        style={styles.deleteButton}
+        onPress={() => handleDeleteCategory(item.id, item.name)}
+      >
+        <Feather name="trash-2" size={18} color={colors.mutedForeground} />
+      </TouchableOpacity>
+    </View>
+  );
+
+  const renderTagItem = ({ item }) => (
+    <View style={styles.itemCard}>
+      <View style={styles.itemContent}>
+        <Feather name="hash" size={18} color={colors.indigo} />
+        <View style={styles.itemInfo}>
+          <Text style={styles.itemName}>{item.name}</Text>
+          <Text style={styles.itemMeta}>{item.link_count || 0} links</Text>
+        </View>
+      </View>
+      <TouchableOpacity
+        style={styles.deleteButton}
+        onPress={() => handleDeleteTag(item.id, item.name)}
+      >
+        <Feather name="trash-2" size={18} color={colors.mutedForeground} />
+      </TouchableOpacity>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.titleBar}>
+        <Text style={styles.title}>Organize</Text>
+      </View>
+
+      {/* Tabs */}
+      <View style={styles.tabs}>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'categories' && styles.tabActive]}
+          onPress={() => setActiveTab('categories')}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              activeTab === 'categories' && styles.tabTextActive,
+            ]}
+          >
+            Categories
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'tags' && styles.tabActive]}
+          onPress={() => setActiveTab('tags')}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              activeTab === 'tags' && styles.tabTextActive,
+            ]}
+          >
+            Tags
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      {activeTab === 'categories' ? (
+        <FlatList
+          data={categories}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={renderCategoryItem}
+          contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.indigo}
+            />
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Feather name="folder" size={48} color={colors.mutedForeground} />
+              <Text style={styles.emptyTitle}>No categories</Text>
+              <Text style={styles.emptyText}>
+                Create categories in the web dashboard
+              </Text>
+            </View>
+          }
+        />
+      ) : (
+        <FlatList
+          data={tags}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={renderTagItem}
+          contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              tintColor={colors.indigo}
+            />
+          }
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Feather name="hash" size={48} color={colors.mutedForeground} />
+              <Text style={styles.emptyTitle}>No tags</Text>
+              <Text style={styles.emptyText}>
+                Create tags in the web dashboard
+              </Text>
+            </View>
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  titleBar: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+  },
+  title: {
+    fontSize: typography.xxxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+  },
+  tabs: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.xl,
+    marginBottom: spacing.lg,
+    gap: spacing.sm,
+  },
+  tab: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.muted,
+  },
+  tabActive: {
+    backgroundColor: colors.foreground,
+  },
+  tabText: {
+    fontSize: typography.sm,
+    fontWeight: typography.medium,
+    color: colors.mutedForeground,
+  },
+  tabTextActive: {
+    color: colors.background,
+  },
+  list: {
+    paddingHorizontal: spacing.xl,
+    paddingBottom: 100,
+  },
+  itemCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+    marginBottom: spacing.md,
+  },
+  itemContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  categoryDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  itemInfo: {
+    gap: 2,
+  },
+  itemName: {
+    fontSize: typography.base,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+  },
+  itemMeta: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+  },
+  deleteButton: {
+    padding: spacing.sm,
+  },
+  emptyState: {
+    alignItems: 'center',
+    paddingVertical: spacing.xxxl * 2,
+  },
+  emptyTitle: {
+    fontSize: typography.xl,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
+  },
+  emptyText: {
+    fontSize: typography.base,
+    color: colors.mutedForeground,
+    textAlign: 'center',
+  },
+});

--- a/mobile-app/src/screens/CreateLinkScreen.js
+++ b/mobile-app/src/screens/CreateLinkScreen.js
@@ -1,0 +1,295 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+import { linksApi, categoriesApi } from '../services/api';
+
+export default function CreateLinkScreen({ navigation }) {
+  const [destination, setDestination] = useState('');
+  const [customCode, setCustomCode] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState(null);
+  const [categories, setCategories] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  const loadCategories = async () => {
+    try {
+      const data = await categoriesApi.getAll();
+      setCategories(data || []);
+    } catch (error) {
+      console.error('Failed to load categories:', error);
+    }
+  };
+
+  const getCategoryColor = (colorName) => {
+    const categoryColors = {
+      work: colors.categories.work,
+      personal: colors.categories.personal,
+      social: colors.categories.social,
+      marketing: colors.categories.marketing,
+    };
+    return categoryColors[colorName] || colors.mutedForeground;
+  };
+
+  const handleCreate = async () => {
+    if (!destination.trim()) {
+      Alert.alert('Error', 'Please enter a destination URL');
+      return;
+    }
+
+    // Basic URL validation
+    let url = destination.trim();
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      url = 'https://' + url;
+    }
+
+    setLoading(true);
+    try {
+      const data = {
+        destination: url,
+      };
+
+      if (customCode.trim()) {
+        data.code = customCode.trim();
+      }
+
+      if (selectedCategory) {
+        data.category_id = selectedCategory;
+      }
+
+      await linksApi.create(data);
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      navigation.goBack();
+    } catch (error) {
+      Alert.alert('Error', error.message || 'Failed to create link');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        style={styles.content}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Destination URL */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Destination URL</Text>
+          <View style={styles.inputContainer}>
+            <Feather name="link" size={18} color={colors.mutedForeground} />
+            <TextInput
+              style={styles.input}
+              placeholder="https://example.com/your-long-url"
+              placeholderTextColor={colors.mutedForeground}
+              value={destination}
+              onChangeText={setDestination}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+            />
+          </View>
+        </View>
+
+        {/* Custom Code (Optional) */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Custom Code (Optional)</Text>
+          <View style={styles.inputContainer}>
+            <Text style={styles.prefix}>/</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="my-custom-link"
+              placeholderTextColor={colors.mutedForeground}
+              value={customCode}
+              onChangeText={setCustomCode}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </View>
+          <Text style={styles.hint}>
+            Leave empty for auto-generated code
+          </Text>
+        </View>
+
+        {/* Category Selection */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Category (Optional)</Text>
+          <View style={styles.categoryGrid}>
+            <TouchableOpacity
+              style={[
+                styles.categoryChip,
+                selectedCategory === null && styles.categoryChipSelected,
+              ]}
+              onPress={() => setSelectedCategory(null)}
+            >
+              <Text
+                style={[
+                  styles.categoryChipText,
+                  selectedCategory === null && styles.categoryChipTextSelected,
+                ]}
+              >
+                None
+              </Text>
+            </TouchableOpacity>
+            {categories.map((cat) => (
+              <TouchableOpacity
+                key={cat.id}
+                style={[
+                  styles.categoryChip,
+                  selectedCategory === cat.id && styles.categoryChipSelected,
+                  selectedCategory === cat.id && {
+                    borderColor: getCategoryColor(cat.color),
+                  },
+                ]}
+                onPress={() => setSelectedCategory(cat.id)}
+              >
+                <View
+                  style={[
+                    styles.categoryDot,
+                    { backgroundColor: getCategoryColor(cat.color) },
+                  ]}
+                />
+                <Text
+                  style={[
+                    styles.categoryChipText,
+                    selectedCategory === cat.id && styles.categoryChipTextSelected,
+                  ]}
+                >
+                  {cat.name}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        {/* Create Button */}
+        <TouchableOpacity
+          style={[styles.createButton, loading && styles.createButtonDisabled]}
+          onPress={handleCreate}
+          disabled={loading}
+          activeOpacity={0.8}
+        >
+          <Feather name="plus" size={20} color="#fff" />
+          <Text style={styles.createButtonText}>
+            {loading ? 'Creating...' : 'Create Link'}
+          </Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+    padding: spacing.xl,
+  },
+  field: {
+    marginBottom: spacing.xl,
+  },
+  label: {
+    fontSize: typography.sm,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+    marginBottom: spacing.sm,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.lg,
+    height: 52,
+    gap: spacing.sm,
+  },
+  prefix: {
+    fontSize: typography.base,
+    color: colors.mutedForeground,
+    fontWeight: typography.medium,
+  },
+  input: {
+    flex: 1,
+    fontSize: typography.base,
+    color: colors.foreground,
+  },
+  hint: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: spacing.sm,
+    marginLeft: spacing.xs,
+  },
+  categoryGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  categoryChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    gap: spacing.sm,
+  },
+  categoryChipSelected: {
+    backgroundColor: colors.muted,
+    borderColor: colors.foreground,
+  },
+  categoryDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  categoryChipText: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+  },
+  categoryChipTextSelected: {
+    color: colors.foreground,
+  },
+  createButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.indigo,
+    borderRadius: borderRadius.lg,
+    height: 52,
+    gap: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  createButtonDisabled: {
+    opacity: 0.6,
+  },
+  createButtonText: {
+    fontSize: typography.base,
+    fontWeight: typography.semibold,
+    color: '#fff',
+  },
+});

--- a/mobile-app/src/screens/LinkDetailScreen.js
+++ b/mobile-app/src/screens/LinkDetailScreen.js
@@ -1,0 +1,379 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  Share,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import * as Haptics from 'expo-haptics';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+import { linksApi } from '../services/api';
+import { API_BASE_URL } from '../constants/config';
+
+export default function LinkDetailScreen({ route, navigation }) {
+  const { code } = route.params;
+  const [link, setLink] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadLink();
+  }, [code]);
+
+  const loadLink = async () => {
+    try {
+      const data = await linksApi.get(code);
+      setLink(data);
+    } catch (error) {
+      Alert.alert('Error', 'Failed to load link details');
+      navigation.goBack();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const shortUrl = `${API_BASE_URL}/${code}`;
+
+  const handleCopy = async () => {
+    await Clipboard.setStringAsync(shortUrl);
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    Alert.alert('Copied!', 'Link copied to clipboard');
+  };
+
+  const handleShare = async () => {
+    try {
+      await Share.share({
+        message: shortUrl,
+        url: shortUrl,
+      });
+    } catch (error) {
+      console.error('Share error:', error);
+    }
+  };
+
+  const handleDelete = () => {
+    Alert.alert(
+      'Delete Link',
+      'Are you sure you want to delete this link? This action cannot be undone.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await linksApi.delete(code);
+              Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+              navigation.goBack();
+            } catch (error) {
+              Alert.alert('Error', 'Failed to delete link');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const getCategoryColor = (colorName) => {
+    const categoryColors = {
+      work: colors.categories.work,
+      personal: colors.categories.personal,
+      social: colors.categories.social,
+      marketing: colors.categories.marketing,
+    };
+    return categoryColors[colorName] || colors.mutedForeground;
+  };
+
+  if (loading || !link) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <Text style={styles.loadingText}>Loading...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+      {/* Short URL Card */}
+      <View style={styles.urlCard}>
+        <Text style={styles.shortUrlLabel}>Short URL</Text>
+        <Text style={styles.shortUrl}>/{link.code}</Text>
+        <View style={styles.urlActions}>
+          <TouchableOpacity style={styles.urlButton} onPress={handleCopy}>
+            <Feather name="copy" size={18} color={colors.foreground} />
+            <Text style={styles.urlButtonText}>Copy</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.urlButton} onPress={handleShare}>
+            <Feather name="share" size={18} color={colors.foreground} />
+            <Text style={styles.urlButtonText}>Share</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Stats */}
+      <View style={styles.statsRow}>
+        <View style={styles.statItem}>
+          <Feather name="mouse-pointer" size={20} color={colors.indigo} />
+          <Text style={styles.statValue}>{link.clicks}</Text>
+          <Text style={styles.statLabel}>Clicks</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statItem}>
+          <Feather name="calendar" size={20} color={colors.indigo} />
+          <Text style={styles.statValue}>
+            {new Date(link.created_at).toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+            })}
+          </Text>
+          <Text style={styles.statLabel}>Created</Text>
+        </View>
+        {link.is_protected && (
+          <>
+            <View style={styles.statDivider} />
+            <View style={styles.statItem}>
+              <Feather name="lock" size={20} color={colors.indigo} />
+              <Text style={styles.statValue}>Yes</Text>
+              <Text style={styles.statLabel}>Protected</Text>
+            </View>
+          </>
+        )}
+      </View>
+
+      {/* Details */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Details</Text>
+        <View style={styles.detailCard}>
+          <View style={styles.detailRow}>
+            <Text style={styles.detailLabel}>Destination</Text>
+            <Text style={styles.detailValue} numberOfLines={2}>
+              {link.destination}
+            </Text>
+          </View>
+
+          {link.category_name && (
+            <View style={styles.detailRow}>
+              <Text style={styles.detailLabel}>Category</Text>
+              <View style={styles.categoryBadge}>
+                <View
+                  style={[
+                    styles.categoryDot,
+                    { backgroundColor: getCategoryColor(link.category_color) },
+                  ]}
+                />
+                <Text style={styles.categoryText}>{link.category_name}</Text>
+              </View>
+            </View>
+          )}
+
+          {link.tags && link.tags.length > 0 && (
+            <View style={styles.detailRow}>
+              <Text style={styles.detailLabel}>Tags</Text>
+              <View style={styles.tagsContainer}>
+                {link.tags.map((tag, index) => (
+                  <View key={index} style={styles.tag}>
+                    <Text style={styles.tagText}>{tag}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          )}
+
+          <View style={styles.detailRow}>
+            <Text style={styles.detailLabel}>Created</Text>
+            <Text style={styles.detailValue}>{formatDate(link.created_at)}</Text>
+          </View>
+
+          {link.expires_at && (
+            <View style={styles.detailRow}>
+              <Text style={styles.detailLabel}>Expires</Text>
+              <Text style={styles.detailValue}>{formatDate(link.expires_at)}</Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* Danger Zone */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Danger Zone</Text>
+        <TouchableOpacity style={styles.deleteButton} onPress={handleDelete}>
+          <Feather name="trash-2" size={18} color={colors.error} />
+          <Text style={styles.deleteButtonText}>Delete Link</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={{ height: 40 }} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: spacing.xl,
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    fontSize: typography.base,
+    color: colors.mutedForeground,
+  },
+  urlCard: {
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.xl,
+    alignItems: 'center',
+  },
+  shortUrlLabel: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginBottom: spacing.sm,
+  },
+  shortUrl: {
+    fontSize: typography.xxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+    marginBottom: spacing.lg,
+  },
+  urlActions: {
+    flexDirection: 'row',
+    gap: spacing.md,
+  },
+  urlButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.muted,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    gap: spacing.sm,
+  },
+  urlButtonText: {
+    fontSize: typography.sm,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginTop: spacing.lg,
+    padding: spacing.lg,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statDivider: {
+    width: 1,
+    backgroundColor: colors.border,
+    marginHorizontal: spacing.md,
+  },
+  statValue: {
+    fontSize: typography.lg,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+    marginTop: spacing.sm,
+  },
+  statLabel: {
+    fontSize: typography.xs,
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  section: {
+    marginTop: spacing.xl,
+  },
+  sectionTitle: {
+    fontSize: typography.sm,
+    fontWeight: typography.semibold,
+    color: colors.mutedForeground,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: spacing.md,
+  },
+  detailCard: {
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+  },
+  detailRow: {
+    marginBottom: spacing.lg,
+  },
+  detailLabel: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginBottom: spacing.xs,
+  },
+  detailValue: {
+    fontSize: typography.base,
+    color: colors.foreground,
+  },
+  categoryBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  categoryDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  categoryText: {
+    fontSize: typography.base,
+    color: colors.foreground,
+  },
+  tagsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  tag: {
+    backgroundColor: colors.muted,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.sm,
+  },
+  tagText: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+  },
+  deleteButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: `${colors.error}15`,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: `${colors.error}30`,
+    padding: spacing.lg,
+    gap: spacing.sm,
+  },
+  deleteButtonText: {
+    fontSize: typography.base,
+    fontWeight: typography.medium,
+    color: colors.error,
+  },
+});

--- a/mobile-app/src/screens/LinksScreen.js
+++ b/mobile-app/src/screens/LinksScreen.js
@@ -1,0 +1,259 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  RefreshControl,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import * as Haptics from 'expo-haptics';
+
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+import { linksApi, statsApi } from '../services/api';
+import LinkCard from '../components/LinkCard';
+import StatsCard from '../components/StatsCard';
+
+export default function LinksScreen({ navigation }) {
+  const [links, setLinks] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [refreshing, setRefreshing] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const loadData = useCallback(async () => {
+    try {
+      const [linksData, statsData] = await Promise.all([
+        linksApi.getAll({ search: searchQuery }),
+        statsApi.get(),
+      ]);
+      setLinks(linksData.links || []);
+      setStats(statsData);
+    } catch (error) {
+      Alert.alert('Error', 'Failed to load data');
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [searchQuery]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await loadData();
+    setRefreshing(false);
+  }, [loadData]);
+
+  const handleCopyLink = async (code) => {
+    await Clipboard.setStringAsync(`${code}`);
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  };
+
+  const handleDeleteLink = (code) => {
+    Alert.alert(
+      'Delete Link',
+      'Are you sure you want to delete this link?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await linksApi.delete(code);
+              Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+              loadData();
+            } catch (error) {
+              Alert.alert('Error', 'Failed to delete link');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const renderHeader = () => (
+    <View style={styles.header}>
+      {/* Stats Row */}
+      <View style={styles.statsRow}>
+        <StatsCard
+          icon="link"
+          value={stats?.total_links || 0}
+          label="Total Links"
+        />
+        <StatsCard
+          icon="mouse-pointer"
+          value={stats?.total_clicks || 0}
+          label="Total Clicks"
+        />
+      </View>
+
+      {/* Search Bar */}
+      <View style={styles.searchContainer}>
+        <Feather name="search" size={18} color={colors.mutedForeground} />
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search links..."
+          placeholderTextColor={colors.mutedForeground}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          returnKeyType="search"
+          onSubmitEditing={loadData}
+        />
+        {searchQuery.length > 0 && (
+          <TouchableOpacity onPress={() => setSearchQuery('')}>
+            <Feather name="x" size={18} color={colors.mutedForeground} />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {/* Section Title */}
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>Recent Links</Text>
+        <Text style={styles.sectionCount}>{links.length} links</Text>
+      </View>
+    </View>
+  );
+
+  const renderEmptyState = () => (
+    <View style={styles.emptyState}>
+      <Feather name="link" size={48} color={colors.mutedForeground} />
+      <Text style={styles.emptyTitle}>No links yet</Text>
+      <Text style={styles.emptyText}>
+        Tap the + button to create your first short link
+      </Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      {/* App Title */}
+      <View style={styles.titleBar}>
+        <Text style={styles.title}>Links</Text>
+        <TouchableOpacity
+          style={styles.profileButton}
+          onPress={() => navigation.navigate('Settings')}
+        >
+          <Feather name="user" size={20} color={colors.foreground} />
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={links}
+        keyExtractor={(item) => item.code}
+        renderItem={({ item }) => (
+          <LinkCard
+            link={item}
+            onPress={() => navigation.navigate('LinkDetail', { code: item.code })}
+            onCopy={() => handleCopyLink(item.code)}
+            onDelete={() => handleDeleteLink(item.code)}
+          />
+        )}
+        ListHeaderComponent={renderHeader}
+        ListEmptyComponent={!loading && renderEmptyState}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.indigo}
+          />
+        }
+        showsVerticalScrollIndicator={false}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  titleBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+  },
+  title: {
+    fontSize: typography.xxxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+  },
+  profileButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.muted,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  header: {
+    paddingHorizontal: spacing.xl,
+    paddingBottom: spacing.lg,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  searchContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.muted,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing.lg,
+    height: 44,
+    gap: spacing.sm,
+    marginBottom: spacing.xl,
+  },
+  searchInput: {
+    flex: 1,
+    color: colors.foreground,
+    fontSize: typography.base,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  sectionTitle: {
+    fontSize: typography.lg,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+  },
+  sectionCount: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+  },
+  listContent: {
+    paddingBottom: 100,
+  },
+  emptyState: {
+    alignItems: 'center',
+    paddingVertical: spacing.xxxl * 2,
+    paddingHorizontal: spacing.xl,
+  },
+  emptyTitle: {
+    fontSize: typography.xl,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
+  },
+  emptyText: {
+    fontSize: typography.base,
+    color: colors.mutedForeground,
+    textAlign: 'center',
+  },
+});

--- a/mobile-app/src/screens/LoginScreen.js
+++ b/mobile-app/src/screens/LoginScreen.js
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import * as WebBrowser from 'expo-web-browser';
+import { colors, spacing, borderRadius, typography, shadows } from '../constants/theme';
+import { API_BASE_URL } from '../constants/config';
+
+export default function LoginScreen({ onLogin }) {
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async () => {
+    setLoading(true);
+    try {
+      // Open Cloudflare Access login in browser
+      // After authentication, the user will be redirected back to the app
+      // with the JWT token
+      const result = await WebBrowser.openAuthSessionAsync(
+        `${API_BASE_URL}/admin`,
+        'linkshort://'
+      );
+
+      if (result.type === 'success' && result.url) {
+        // Extract token from URL if available
+        // For now, we'll use a simple approach
+        onLogin();
+      }
+    } catch (error) {
+      console.error('Login error:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        {/* Logo */}
+        <View style={styles.logoContainer}>
+          <View style={styles.logo}>
+            <Feather name="link" size={40} color={colors.indigo} />
+          </View>
+        </View>
+
+        {/* Title */}
+        <Text style={styles.title}>LinkShort</Text>
+        <Text style={styles.subtitle}>
+          Manage your short links on the go
+        </Text>
+
+        {/* Features */}
+        <View style={styles.features}>
+          <View style={styles.feature}>
+            <View style={styles.featureIcon}>
+              <Feather name="zap" size={18} color={colors.indigo} />
+            </View>
+            <View style={styles.featureText}>
+              <Text style={styles.featureTitle}>Quick Access</Text>
+              <Text style={styles.featureDesc}>
+                Create and manage links instantly
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.feature}>
+            <View style={styles.featureIcon}>
+              <Feather name="bar-chart-2" size={18} color={colors.indigo} />
+            </View>
+            <View style={styles.featureText}>
+              <Text style={styles.featureTitle}>Analytics</Text>
+              <Text style={styles.featureDesc}>
+                Track clicks and performance
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.feature}>
+            <View style={styles.featureIcon}>
+              <Feather name="shield" size={18} color={colors.indigo} />
+            </View>
+            <View style={styles.featureText}>
+              <Text style={styles.featureTitle}>Secure</Text>
+              <Text style={styles.featureDesc}>
+                Protected by Cloudflare Access
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Login Button */}
+        <TouchableOpacity
+          style={styles.loginButton}
+          onPress={handleLogin}
+          disabled={loading}
+          activeOpacity={0.8}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <>
+              <Feather name="log-in" size={20} color="#fff" />
+              <Text style={styles.loginButtonText}>
+                Sign in with Cloudflare
+              </Text>
+            </>
+          )}
+        </TouchableOpacity>
+
+        {/* Info */}
+        <Text style={styles.infoText}>
+          You'll be redirected to Cloudflare Access to authenticate
+        </Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+    justifyContent: 'center',
+  },
+  logoContainer: {
+    alignItems: 'center',
+    marginBottom: spacing.xl,
+  },
+  logo: {
+    width: 80,
+    height: 80,
+    borderRadius: borderRadius.xl,
+    backgroundColor: `${colors.indigo}20`,
+    justifyContent: 'center',
+    alignItems: 'center',
+    ...shadows.lg,
+  },
+  title: {
+    fontSize: 36,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontSize: typography.lg,
+    color: colors.mutedForeground,
+    textAlign: 'center',
+    marginBottom: spacing.xxxl,
+  },
+  features: {
+    marginBottom: spacing.xxxl,
+    gap: spacing.lg,
+  },
+  feature: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  featureIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    backgroundColor: `${colors.indigo}15`,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  featureText: {
+    flex: 1,
+  },
+  featureTitle: {
+    fontSize: typography.base,
+    fontWeight: typography.semibold,
+    color: colors.foreground,
+  },
+  featureDesc: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  loginButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.indigo,
+    borderRadius: borderRadius.lg,
+    height: 56,
+    gap: spacing.sm,
+    ...shadows.md,
+  },
+  loginButtonText: {
+    fontSize: typography.lg,
+    fontWeight: typography.semibold,
+    color: '#fff',
+  },
+  infoText: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    textAlign: 'center',
+    marginTop: spacing.lg,
+  },
+});

--- a/mobile-app/src/screens/SettingsScreen.js
+++ b/mobile-app/src/screens/SettingsScreen.js
@@ -1,0 +1,238 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  Linking,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Feather } from '@expo/vector-icons';
+import { colors, spacing, borderRadius, typography } from '../constants/theme';
+import { API_BASE_URL } from '../constants/config';
+
+export default function SettingsScreen({ onLogout, userEmail }) {
+  const handleLogout = () => {
+    Alert.alert(
+      'Log Out',
+      'Are you sure you want to log out?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Log Out',
+          style: 'destructive',
+          onPress: onLogout,
+        },
+      ]
+    );
+  };
+
+  const openWebDashboard = () => {
+    Linking.openURL(`${API_BASE_URL}/admin`);
+  };
+
+  const SettingRow = ({ icon, title, subtitle, onPress, showChevron = true, danger = false }) => (
+    <TouchableOpacity
+      style={styles.settingRow}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
+      <View style={[styles.settingIcon, danger && styles.settingIconDanger]}>
+        <Feather
+          name={icon}
+          size={20}
+          color={danger ? colors.error : colors.indigo}
+        />
+      </View>
+      <View style={styles.settingContent}>
+        <Text style={[styles.settingTitle, danger && styles.settingTitleDanger]}>
+          {title}
+        </Text>
+        {subtitle && <Text style={styles.settingSubtitle}>{subtitle}</Text>}
+      </View>
+      {showChevron && (
+        <Feather name="chevron-right" size={20} color={colors.mutedForeground} />
+      )}
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.titleBar}>
+        <Text style={styles.title}>Settings</Text>
+      </View>
+
+      <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
+        {/* Account Section */}
+        <Text style={styles.sectionTitle}>Account</Text>
+        <View style={styles.card}>
+          <View style={styles.profileRow}>
+            <View style={styles.avatar}>
+              <Feather name="user" size={24} color={colors.foreground} />
+            </View>
+            <View style={styles.profileInfo}>
+              <Text style={styles.profileName}>
+                {userEmail || 'Not logged in'}
+              </Text>
+              <Text style={styles.profileMeta}>Cloudflare Access</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* General Section */}
+        <Text style={styles.sectionTitle}>General</Text>
+        <View style={styles.card}>
+          <SettingRow
+            icon="globe"
+            title="Web Dashboard"
+            subtitle="Open full dashboard in browser"
+            onPress={openWebDashboard}
+          />
+          <View style={styles.divider} />
+          <SettingRow
+            icon="bell"
+            title="Notifications"
+            subtitle="Coming soon"
+            onPress={() => Alert.alert('Coming Soon', 'Push notifications will be available in a future update.')}
+          />
+        </View>
+
+        {/* About Section */}
+        <Text style={styles.sectionTitle}>About</Text>
+        <View style={styles.card}>
+          <SettingRow
+            icon="info"
+            title="Version"
+            subtitle="1.0.0"
+            showChevron={false}
+          />
+          <View style={styles.divider} />
+          <SettingRow
+            icon="github"
+            title="Source Code"
+            subtitle="View on GitHub"
+            onPress={() => Linking.openURL('https://github.com')}
+          />
+        </View>
+
+        {/* Danger Zone */}
+        <Text style={styles.sectionTitle}>Account</Text>
+        <View style={styles.card}>
+          <SettingRow
+            icon="log-out"
+            title="Log Out"
+            onPress={handleLogout}
+            showChevron={false}
+            danger
+          />
+        </View>
+
+        <View style={{ height: 100 }} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  titleBar: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+  },
+  title: {
+    fontSize: typography.xxxl,
+    fontWeight: typography.bold,
+    color: colors.foreground,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.xl,
+  },
+  sectionTitle: {
+    fontSize: typography.sm,
+    fontWeight: typography.semibold,
+    color: colors.mutedForeground,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: spacing.xl,
+    marginBottom: spacing.md,
+    marginLeft: spacing.xs,
+  },
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    overflow: 'hidden',
+  },
+  profileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: colors.muted,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  profileInfo: {
+    flex: 1,
+  },
+  profileName: {
+    fontSize: typography.base,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+  },
+  profileMeta: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  settingIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    backgroundColor: `${colors.indigo}20`,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  settingIconDanger: {
+    backgroundColor: `${colors.error}20`,
+  },
+  settingContent: {
+    flex: 1,
+  },
+  settingTitle: {
+    fontSize: typography.base,
+    fontWeight: typography.medium,
+    color: colors.foreground,
+  },
+  settingTitleDanger: {
+    color: colors.error,
+  },
+  settingSubtitle: {
+    fontSize: typography.sm,
+    color: colors.mutedForeground,
+    marginTop: 2,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginLeft: spacing.lg + 36 + spacing.md,
+  },
+});

--- a/mobile-app/src/services/api.js
+++ b/mobile-app/src/services/api.js
@@ -1,0 +1,131 @@
+import * as SecureStore from 'expo-secure-store';
+import { API_BASE_URL } from '../constants/config';
+
+// Store the auth token
+let authToken = null;
+
+export const setAuthToken = async (token) => {
+  authToken = token;
+  if (token) {
+    await SecureStore.setItemAsync('authToken', token);
+  } else {
+    await SecureStore.deleteItemAsync('authToken');
+  }
+};
+
+export const loadAuthToken = async () => {
+  authToken = await SecureStore.getItemAsync('authToken');
+  return authToken;
+};
+
+// Base fetch wrapper with auth
+const apiFetch = async (endpoint, options = {}) => {
+  const url = `${API_BASE_URL}${endpoint}`;
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...options.headers,
+  };
+
+  // Add auth token if available (Cloudflare Access JWT)
+  if (authToken) {
+    headers['Cf-Access-Jwt-Assertion'] = authToken;
+  }
+
+  const response = await fetch(url, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || `HTTP ${response.status}`);
+  }
+
+  // Handle empty responses
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+};
+
+// Links API
+export const linksApi = {
+  getAll: (params = {}) => {
+    const query = new URLSearchParams(params).toString();
+    return apiFetch(`/api/links${query ? `?${query}` : ''}`);
+  },
+
+  get: (code) => apiFetch(`/api/links/${code}`),
+
+  create: (data) =>
+    apiFetch('/api/links', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  update: (code, data) =>
+    apiFetch(`/api/links/${code}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  delete: (code) =>
+    apiFetch(`/api/links/${code}`, {
+      method: 'DELETE',
+    }),
+};
+
+// Categories API
+export const categoriesApi = {
+  getAll: () => apiFetch('/api/categories'),
+
+  create: (data) =>
+    apiFetch('/api/categories', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  update: (id, data) =>
+    apiFetch(`/api/categories/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  delete: (id) =>
+    apiFetch(`/api/categories/${id}`, {
+      method: 'DELETE',
+    }),
+};
+
+// Tags API
+export const tagsApi = {
+  getAll: () => apiFetch('/api/tags'),
+
+  create: (data) =>
+    apiFetch('/api/tags', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  delete: (id) =>
+    apiFetch(`/api/tags/${id}`, {
+      method: 'DELETE',
+    }),
+};
+
+// Stats API
+export const statsApi = {
+  get: () => apiFetch('/api/stats'),
+  getClickEvents: (linkId, params = {}) => {
+    const query = new URLSearchParams(params).toString();
+    return apiFetch(`/api/links/${linkId}/clicks${query ? `?${query}` : ''}`);
+  },
+};
+
+export default {
+  setAuthToken,
+  loadAuthToken,
+  links: linksApi,
+  categories: categoriesApi,
+  tags: tagsApi,
+  stats: statsApi,
+};


### PR DESCRIPTION
Adds a complete mobile app structure for iOS (and Android) using Expo:

Structure:
- App.js - Entry point with auth state management
- src/constants/theme.js - Design tokens matching web app's Shadcn dark theme
- src/constants/config.js - API configuration
- src/services/api.js - API client for links, categories, tags, stats
- src/navigation/ - Bottom tab navigator + stack navigator
- src/screens/ - Links, Analytics, Categories, Settings, CreateLink, LinkDetail, Login
- src/components/ - Reusable LinkCard, StatsCard components

Features:
- Bottom tab navigation with floating "+" button (matching mockup design)
- Links list with search, pull-to-refresh, copy/delete actions
- Analytics dashboard with stats overview
- Categories and tags management
- Create new links with category selection
- Link detail view with share/copy/delete
- Cloudflare Access authentication flow
- Dark theme throughout

To test:
1. cd mobile-app && npm install
2. Update src/constants/config.js with your worker URL
3. npx expo start
4. Scan QR code with Expo Go app on iPhone

https://claude.ai/code/session_01HMHrZnyXxFsKW3wDrkkvAa