### PR TITLE
fix: add keep_vars to preserve dashboard environment variables

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,7 @@ name = "url-shortener"
 main = "src/index.js"
 compatibility_date = "2024-01-01"
 compatibility_flags = ["nodejs_compat"]
+keep_vars = true  # Preserve dashboard-set environment variables during deploy
 
 [vars]
 # Clerk environment variables - set actual values in Cloudflare dashboard or use wrangler secret


### PR DESCRIPTION
Wrangler deploy was overwriting the CLERK_PUBLISHABLE_KEY set in the Cloudflare dashboard. Adding keep_vars = true preserves existing dashboard-set variables during deployment.

https://claude.ai/code/session_0145XPe7Hzn1cV8W98wX78rd