### PR TITLE
fix: replace deprecated Clerk redirect props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1674,13 +1674,13 @@ function getAuthPageHTML(env, mode = 'login') {
 
         ${isSignup ? `
         clerk.mountSignUp(container, {
-          afterSignUpUrl: '/admin',
+          fallbackRedirectUrl: '/admin',
           signInUrl: '/login',
           appearance: CLERK_APPEARANCE
         });
         ` : `
         clerk.mountSignIn(container, {
-          afterSignInUrl: '/admin',
+          fallbackRedirectUrl: '/admin',
           signUpUrl: '/signup',
           appearance: CLERK_APPEARANCE
         });


### PR DESCRIPTION
Replace afterSignUpUrl/afterSignInUrl with fallbackRedirectUrl as per Clerk's deprecation warning.

https://claude.ai/code/session_0145XPe7Hzn1cV8W98wX78rd