### PR TITLE
fix: use character loop instead of regex in escapeJs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5347,17 +5347,20 @@ function getAdminHTML(userEmail, env) {
 
     // Escape for use in JavaScript string literals (client-side version)
     function escapeJs(str) {
-      if (!str) return '';
-      var result = '';
-      for (var i = 0; i < str.length; i++) {
-        var c = str[i];
-        if (c === '\\\\') result += '\\\\\\\\';
-        else if (c === "'") result += "\\\\'";
-        else if (c === '"') result += '\\\\"';
-        else if (c === '\\n') result += '\\\\n';
-        else if (c === '\\r') result += '\\\\r';
-        else if (c === '\\t') result += '\\\\t';
-        else result += c;
+      if (str === null || str === undefined) return '';
+      str = String(str);
+      let result = '';
+      for (let i = 0; i < str.length; i++) {
+        const c = str[i];
+        switch (c) {
+          case '\\\\': result += '\\\\\\\\'; break;
+          case "'": result += "\\\\'"; break;
+          case '"': result += '\\\\"'; break;
+          case '\n': result += '\\\\n'; break;
+          case '\r': result += '\\\\r'; break;
+          case '\t': result += '\\\\t'; break;
+          default: result += c;
+        }
       }
       return result;
     }


### PR DESCRIPTION
Replace regex-based escaping with character-by-character loop to avoid backslash escaping issues in template literals.

Fixes: Uncaught SyntaxError: Invalid regular expression: missing /

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch escapeJs from regex-based replacements to a character-by-character loop to correctly escape backslashes, quotes, and control characters in template literals. This resolves the “Uncaught SyntaxError: Invalid regular expression: missing /” seen in admin HTML rendering with certain inputs.

<sup>Written for commit 2658205485923a328e37f9f7e89a2f14c1410aee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

