### PR TITLE
fix: use charCode to avoid template literal newline issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5352,15 +5352,14 @@ function getAdminHTML(userEmail, env) {
       let result = '';
       for (let i = 0; i < str.length; i++) {
         const c = str[i];
-        switch (c) {
-          case '\\\\': result += '\\\\\\\\'; break;
-          case "'": result += "\\\\'"; break;
-          case '"': result += '\\\\"'; break;
-          case '\n': result += '\\\\n'; break;
-          case '\r': result += '\\\\r'; break;
-          case '\t': result += '\\\\t'; break;
-          default: result += c;
-        }
+        const code = str.charCodeAt(i);
+        if (c === '\\\\') result += '\\\\\\\\';
+        else if (c === "'") result += "\\\\'";
+        else if (c === '"') result += '\\\\"';
+        else if (code === 10) result += '\\\\n';  // newline
+        else if (code === 13) result += '\\\\r';  // carriage return
+        else if (code === 9) result += '\\\\t';   // tab
+        else result += c;
       }
       return result;
     }


### PR DESCRIPTION
Change from checking character literals ('\n', '\r', '\t') to checking character codes (10, 13, 9) using charCodeAt().

This prevents template literal processing from converting escape sequences into actual newline/tab characters which cause syntax errors.

Fixes: Uncaught SyntaxError: Invalid or unexpected token

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix string escaping in getAdminHTML by checking char codes (10, 13, 9) instead of character literals. Prevents template literals from turning escapes into real newlines/tabs and fixes the “Invalid or unexpected token” SyntaxError.

- **Bug Fixes**
  - Use charCodeAt for newline, carriage return, and tab detection.
  - Preserve escaping for backslash, single quote, and double quote.
  - Eliminates runtime crash: Uncaught SyntaxError: Invalid or unexpected token.

<sup>Written for commit 9831b7bc0634f8220d4f1e5e4686ce8b6914ce54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

