### PR TITLE
fix: use charCodeAt() for all special characters in escapeJs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5353,12 +5353,12 @@ function getAdminHTML(userEmail, env) {
       for (let i = 0; i < str.length; i++) {
         const c = str[i];
         const code = str.charCodeAt(i);
-        if (c === '\\\\') result += '\\\\\\\\';
-        else if (c === "'") result += "\\\\'";
-        else if (c === '"') result += '\\\\"';
-        else if (code === 10) result += '\\\\n';  // newline
-        else if (code === 13) result += '\\\\r';  // carriage return
-        else if (code === 9) result += '\\\\t';   // tab
+        if (code === 92) result += '\\\\\\\\';   // backslash
+        else if (code === 39) result += "\\\\'"; // single quote
+        else if (code === 34) result += '\\\\"'; // double quote
+        else if (code === 10) result += '\\\\n'; // newline
+        else if (code === 13) result += '\\\\r'; // carriage return
+        else if (code === 9) result += '\\\\t';  // tab
         else result += c;
       }
       return result;


### PR DESCRIPTION
Use character codes instead of literals for backslash (92), single quote (39), and double quote (34) to avoid template literal escape sequence processing issues.

This makes the function consistent - all special characters now use charCodeAt() instead of mixing character literals and codes.

https://claude.ai/code/session_lYOO5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch escapeJs to use character codes for backslash (92), single quote (39), and double quote (34) instead of character literals. This prevents template literal escape issues and makes all special-character checks consistent.

<sup>Written for commit fdb860b7f6ee4685e7565c973916d9b90cce5862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

