### PR TITLE
fix: escape single quotes in upgradeModal cancel button

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7668,7 +7668,7 @@ Create .github/workflows/update-preview-link.yml that:
         '</div></div>' +
         '<div style="display:flex;gap:8px;">' +
         '<button onclick="startCheckout()" style="flex:1;padding:10px;background:oklch(0.6 0.2 290);color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;">Upgrade to Pro</button>' +
-        '<button onclick="document.getElementById('upgradeModal').remove()" style="padding:10px 16px;background:oklch(0.2 0.01 260);color:oklch(0.7 0.02 260);border:none;border-radius:8px;font-size:14px;cursor:pointer;">Cancel</button>' +
+        '<button onclick="document.getElementById(\'upgradeModal\').remove()" style="padding:10px 16px;background:oklch(0.2 0.01 260);color:oklch(0.7 0.02 260);border:none;border-radius:8px;font-size:14px;cursor:pointer;">Cancel</button>' +
         '</div></div>';
       modal.addEventListener('click', e => { if (e.target === modal) modal.remove(); });
       document.body.appendChild(modal);


### PR DESCRIPTION
## Summary

- Fixes a JavaScript syntax error in the upgrade modal's Cancel button
- Unescaped single quotes `'upgradeModal'` inside a single-quoted string literal caused a browser parse error
- This broke **all JavaScript** on the admin page: settings tabs non-functional, links list empty (loadLinks() never ran)

## Root Cause

```js
// Before (broken): single quotes inside a single-quoted string
'<button onclick="document.getElementById('upgradeModal').remove()">'

// After (fixed): escaped single quotes
'<button onclick="document.getElementById(\'upgradeModal\').remove()">'
```

## Test plan
- [ ] Visit urlstogo.cloud/admin — settings tabs should work
- [ ] Links list should load immediately
- [ ] Upgrade modal Cancel button should dismiss the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escaped single quotes in the upgrade modal Cancel button’s onclick string to fix a JS syntax error that broke all admin page scripts. Restores working settings tabs, loads the links list, and lets Cancel close the modal.

<sup>Written for commit 38460c84f7a5820a1f10cf15ff9b74d7477cfb0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

