### PR TITLE
fix: double-escape upgradeModal button onclick in template literal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7672,7 +7672,7 @@ Create .github/workflows/update-preview-link.yml that:
         '</div></div>' +
         '<div style="display:flex;gap:8px;">' +
         '<button onclick="startCheckout()" style="flex:1;padding:10px;background:oklch(0.6 0.2 290);color:#fff;border:none;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;">Upgrade to Pro</button>' +
-        '<button onclick="document.getElementById(\'upgradeModal\').remove()" style="padding:10px 16px;background:oklch(0.2 0.01 260);color:oklch(0.7 0.02 260);border:none;border-radius:8px;font-size:14px;cursor:pointer;">Cancel</button>' +
+        '<button onclick="document.getElementById(\\'upgradeModal\\').remove()" style="padding:10px 16px;background:oklch(0.2 0.01 260);color:oklch(0.7 0.02 260);border:none;border-radius:8px;font-size:14px;cursor:pointer;">Cancel</button>' +
         '</div></div>';
       modal.addEventListener('click', e => { if (e.target === modal) modal.remove(); });
       document.body.appendChild(modal);


### PR DESCRIPTION
## Root Cause

`showUpgradeModal` builds a button string using `\'upgradeModal\'` escape sequences. However, this function lives inside a template literal (the `getAdminHTML` backtick string). JavaScript template literals consume backslash escapes before the string is evaluated, so `\'` becomes `'` in the rendered HTML — leaving the browser with an unescaped `'upgradeModal'` in the middle of a single-quoted JS string.

This caused `SyntaxError: Unexpected identifier 'upgradeModal'` which aborted the entire `<script>` block, leaving every app function undefined (settings navigation, link creation, etc.).

## Fix

Changed `\'upgradeModal\'` to `\\'upgradeModal\\'`. Inside the template literal, `\\` renders as `\`, so the browser receives `\'upgradeModal\'` — a valid escape sequence within the single-quoted string.

## Test Plan

- [ ] Reload admin page — no SyntaxError in console
- [ ] Settings navigation works (All Settings, Git Sync, API Keys)
- [ ] Create link works
- [ ] Billing panel loads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a quote-escaping bug in the upgrade modal that crashed the admin page script by double-escaping the 'upgradeModal' ID in the Cancel button’s onclick within the template literal.

<sup>Written for commit 22d250cde02d1e1a1e08e50d0f9c4d38110c5544. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

