### PR TITLE
fix: Stripe customer metadata URLSearchParams serialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1592,7 +1592,7 @@ export default {
         if (existing?.stripe_customer_id) {
           customerId = existing.stripe_customer_id;
         } else {
-          const cust = await stripeRequest('POST', '/customers', { email: userEmail, metadata: { app: 'urlstogo' } }, env);
+          const cust = await stripeRequest('POST', '/customers', { email: userEmail, 'metadata[app]': 'urlstogo' }, env);
           if (cust.error) return jsonResponse({ error: cust.error.message || 'Failed to create customer' }, { status: 500 });
           customerId = cust.id;
         }


### PR DESCRIPTION
## Summary
- Fixes checkout failing with "Invalid value for \`metadata\`" error
- Root cause: `URLSearchParams` can't serialize nested objects — `{ metadata: { app: 'urlstogo' } }` becomes `metadata=[object+Object]`
- Fix: use flat bracket notation `'metadata[app]': 'urlstogo'` consistent with the rest of the checkout session body

## Test plan
- [ ] Click "Upgrade to Pro" in billing panel
- [ ] Should redirect to Stripe Checkout (not show an error toast)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes checkout failures by sending Stripe customer metadata using flat bracket notation. Replaces { metadata: { app: 'urlstogo' } } with 'metadata[app]': 'urlstogo' to avoid URLSearchParams converting nested objects to [object Object].

<sup>Written for commit 27da45e5b9986aa93a7a224b896ee701e8105215. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

