### PR TITLE
fix: remove invalid customer_update[email] from checkout session

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1607,7 +1607,6 @@ export default {
           cancel_url: cancelUrl,
           'subscription_data[metadata][app]': 'urlstogo',
           'subscription_data[metadata][user_email]': userEmail,
-          'customer_update[email]': 'auto',
         }, env);
         if (session.error) return jsonResponse({ error: session.error.message || 'Checkout session failed' }, { status: 500 });
         return jsonResponse({ url: session.url });


### PR DESCRIPTION
## Summary
- Removes `customer_update[email]` — not a valid field for this parameter
- Valid `customer_update` fields are: `address`, `name`, `shipping`
- Was causing "Received unknown parameter" 500 error from Stripe

## Test plan
- [ ] Click "Upgrade to Pro" — should redirect to Stripe Checkout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the invalid customer_update[email] param from Stripe Checkout session creation to stop Stripe 500 “Received unknown parameter” errors. Checkout sessions now create successfully and redirect to Stripe as expected.

<sup>Written for commit e2f1afdbb538eedbf0560d0c51ec8dc82874aa0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

