### PR TITLE
fix: escape template literal in sidebar stats widget

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7484,7 +7484,7 @@ Create .github/workflows/update-preview-link.yml that:
       let sub = 'clicks today';
       if (yesterday > 0) {
         const pct = Math.round((today - yesterday) / yesterday * 100);
-        sub = `clicks \u00b7 ${pct >= 0 ? '+' : ''}${pct}% vs yesterday`;
+        sub = \`clicks \u00b7 \${pct >= 0 ? '+' : ''}\${pct}% vs yesterday\`;
       }
       document.getElementById('sidebarClicksSub').textContent = sub;
     }


### PR DESCRIPTION
## Summary
- Fixes build failure from PR #85 (sidebar upgrade)
- The `sub = \`clicks...\`` template literal in `loadStats()` used unescaped backticks
- Since `loadStats()` is embedded inside the `getAdminHTML()` outer template literal (starts line 4454), inner backticks must be escaped as `\`` and interpolations as `\${...}`
- All other client-side template literals in this file follow this pattern

## Test plan
- [ ] Deploy succeeds (no esbuild parse error)
- [ ] Sidebar stats widget shows today's click count
- [ ] Sub-text shows "clicks today" or "clicks · +N% vs yesterday" correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a build failure by escaping the inner template literal in the sidebar stats widget. The "clicks" sub-text now renders correctly and shows today's count and % vs yesterday.

<sup>Written for commit a641bea5c5f0997caf2a309230c28bb1d9f80d47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

