### PR TITLE
fix: correct auth email lookup + Playwright E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+name: E2E Tests
+
+# Runs after the main deploy completes, testing the live Worker
+on:
+  workflow_run:
+    workflows: ['Deploy']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'URL to test against'
+        default: 'https://urlstogo.cloud'
+        required: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        env:
+          BASE_URL: ${{ inputs.base_url || 'https://urlstogo.cloud' }}
+          CLERK_TEST_EMAIL: ${{ secrets.CLERK_TEST_EMAIL }}
+          CLERK_TEST_PASSWORD: ${{ secrets.CLERK_TEST_PASSWORD }}
+        run: npx playwright test
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ Thumbs.db
 *.log
 npm-debug.log*
 .claude/session-cache.json
+
+# Playwright
+playwright-report/
+playwright/.auth/
+test-results/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "playwright test",
+    "test:auth": "playwright test tests/fixtures/auth.setup.ts",
+    "test:ui": "playwright test --ui"
   },
   "repository": {
     "type": "git",
@@ -25,6 +27,7 @@
     "tweetsodium": "^0.0.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "wrangler": "^4.61.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * E2E tests run against the deployed Cloudflare Worker.
+ * No local dev server — tests hit the live URL.
+ *
+ * Auth: Clerk session is pre-saved via `npm run test:auth`.
+ * Run that once to generate playwright/.auth/user.json, then tests use it.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['list'],
+  ],
+  use: {
+    baseURL: process.env.BASE_URL || 'https://urlstogo.cloud',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15000,
+    navigationTimeout: 30000,
+  },
+  projects: [
+    // Auth setup — runs first, generates playwright/.auth/user.json
+    {
+      name: 'setup',
+      testMatch: '**/auth.setup.ts',
+    },
+    // Main tests — depend on auth setup
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+  ],
+})

--- a/tests/e2e/features/links.spec.ts
+++ b/tests/e2e/features/links.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke tests for the links dashboard.
+ *
+ * These tests catch the class of bug where getUserEmail() returns a user ID
+ * instead of an email, causing the /api/links query to return 0 results.
+ *
+ * Assumes the test account has at least 1 link stored.
+ */
+test.describe('Links dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin')
+    // Wait for the links table to be present in the DOM
+    await page.waitForSelector('#linksTable', { timeout: 15000 })
+  })
+
+  test('admin page loads and shows sidebar', async ({ page }) => {
+    await expect(page.locator('.sidebar')).toBeVisible()
+    await expect(page.locator('#linksTable')).toBeVisible()
+  })
+
+  test('links table is not empty after auth', async ({ page }) => {
+    // Wait for rows — guards against the user_email mismatch bug
+    // (empty table = getUserEmail returned wrong value, or API error)
+    await page.waitForSelector('#linksTable tr[data-code]', { timeout: 10000 })
+    const rows = page.locator('#linksTable tr[data-code]')
+    await expect(rows.first()).toBeVisible()
+    const count = await rows.count()
+    expect(count).toBeGreaterThan(0)
+  })
+
+  test('API /api/links returns an array', async ({ page, request }) => {
+    // Pull session cookies from the page context
+    const cookies = await page.context().cookies()
+    const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ')
+
+    const res = await request.get('/api/links?sort=newest', {
+      headers: { Cookie: cookieHeader },
+    })
+
+    expect(res.ok()).toBe(true)
+    const body = await res.json()
+    expect(Array.isArray(body)).toBe(true)
+    expect(body.length).toBeGreaterThan(0)
+  })
+
+  test('tag filter chips are visible', async ({ page }) => {
+    await expect(page.locator('#tagFilterChips')).toBeVisible()
+    // "All" chip is always present
+    await expect(page.locator('#tagFilterChips .tag-chip').first()).toContainText('All')
+  })
+
+  test('search filters links by code', async ({ page }) => {
+    await page.waitForSelector('#linksTable tr[data-code]')
+    const totalRows = await page.locator('#linksTable tr[data-code]').count()
+
+    // Type a query that won't match anything
+    await page.fill('#tableSearch', 'xyznonexistent_abc123')
+    await page.waitForTimeout(300)
+
+    const visibleRows = await page.locator('#linksTable tr[data-code]:visible').count()
+    // Either 0 rows visible or table shows empty state
+    expect(visibleRows).toBeLessThan(totalRows)
+  })
+
+  test('create link sheet opens', async ({ page }) => {
+    await page.waitForSelector('#linksTable tr[data-code]')
+    await page.click('button:has-text("Create Link")')
+    // Bottom sheet or modal should appear
+    await expect(page.locator('.sheet, .modal, [id*="create"], [id*="sheet"]').first()).toBeVisible({ timeout: 5000 })
+  })
+})

--- a/tests/fixtures/auth.setup.ts
+++ b/tests/fixtures/auth.setup.ts
@@ -1,0 +1,43 @@
+import { test as setup, expect } from '@playwright/test'
+import path from 'path'
+
+const authFile = path.join(__dirname, '../../playwright/.auth/user.json')
+
+/**
+ * Auth setup — signs in via Clerk and saves session cookies to
+ * playwright/.auth/user.json so all other tests skip the login flow.
+ *
+ * Requires CLERK_TEST_EMAIL and CLERK_TEST_PASSWORD env vars, OR run
+ * manually: npx playwright codegen https://urlstogo.cloud/admin
+ * and save the auth state from the browser.
+ */
+setup('authenticate', async ({ page }) => {
+  const email = process.env.CLERK_TEST_EMAIL
+  const password = process.env.CLERK_TEST_PASSWORD
+
+  if (!email || !password) {
+    throw new Error(
+      'Set CLERK_TEST_EMAIL and CLERK_TEST_PASSWORD to run auth setup.\n' +
+      'Or generate auth state manually: npx playwright codegen https://urlstogo.cloud/admin'
+    )
+  }
+
+  await page.goto('/admin')
+
+  // Wait for Clerk login form
+  await page.waitForSelector('input[name="identifier"], input[type="email"]', { timeout: 15000 })
+
+  await page.fill('input[name="identifier"], input[type="email"]', email)
+  await page.click('button[type="submit"], button:has-text("Continue")')
+
+  // Password step
+  await page.waitForSelector('input[type="password"]', { timeout: 10000 })
+  await page.fill('input[type="password"]', password)
+  await page.click('button[type="submit"], button:has-text("Sign in")')
+
+  // Wait for admin dashboard to load (sidebar is the reliable indicator)
+  await page.waitForSelector('.sidebar', { timeout: 20000 })
+  await expect(page).toHaveURL(/admin/)
+
+  await page.context().storageState({ path: authFile })
+})


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `getUserEmail()` was falling back to the Clerk user ID (`user_38zoejbWFItGStGj6ZunyTkZ9Qt`) when `emailAddresses[0]` was unavailable. D1 queries used this ID as `user_email`, returning 0 results since all links are stored under `admin@jbmdcreations.com`
- **Fix**: now resolves the primary email via `primaryEmailAddressId`, then falls back to `emailAddresses[0]`, and returns `null` (proper 401) if no email found — never the user ID
- **Defensive**: `loadLinks()` now checks `res.ok` and `Array.isArray` before using the response, so a 401 error JSON no longer causes a silent JS crash that leaves the table empty
- **D1 already cleaned**: 5 orphaned categories under the Clerk user ID deleted directly via D1 MCP (they were exact duplicates of existing `admin@jbmdcreations.com` categories with no linked links)

## Playwright E2E Added

Tests in `tests/e2e/features/links.spec.ts`:
- Admin page loads with sidebar visible
- Links table is NOT empty after auth (directly catches this class of bug)
- `/api/links` returns an array
- Tag filter chips visible
- Search filter reduces row count
- Create Link button opens sheet

Auth setup via `tests/fixtures/auth.setup.ts` — saves Clerk session to `playwright/.auth/user.json`.

CI: `.github/workflows/e2e.yml` triggers after the Deploy workflow completes on main.

## Test plan

- [ ] Merge → auto-deploy
- [ ] Verify admin dashboard shows 32 links
- [ ] Add `CLERK_TEST_EMAIL` + `CLERK_TEST_PASSWORD` to GitHub secrets
- [ ] Run `npm run test:auth` locally once to generate `playwright/.auth/user.json`
- [ ] Run `npm test` to verify E2E passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auth email lookup to use the user’s primary email, which fixes empty link tables after sign-in. Adds Playwright E2E tests with a post-deploy CI workflow, and introduces tag filter chips in the dashboard.

- **Bug Fixes**
  - getUserEmail now resolves primaryEmailAddressId, falls back to first email, and never returns the Clerk user ID; returns null for proper 401s.
  - loadLinks checks res.ok and Array.isArray before use to avoid crashes and silent empty states.

- **New Features**
  - Tag filter chips added to the links toolbar; search and tag filters now combine.
  - Playwright E2E smoke tests for admin load, non-empty table, API response shape, filters, and create-link sheet.
  - CI workflow runs E2E after Deploy against the live URL; requires CLERK_TEST_EMAIL and CLERK_TEST_PASSWORD secrets. Added Playwright config, scripts, and dev dependency.

<sup>Written for commit 0eb97481ef8762dd5de6297f94c20cc45ae61021. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

